### PR TITLE
Improve test for the existence of configs/config

### DIFF
--- a/bin/lambda.sh
+++ b/bin/lambda.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 set -eu
 
+if [[ ! -f configs/config ]]; then
+  echo "Your are missing config/configs"
+  echo "Make sure to create one using the provided template"
+  exit 1
+fi
+
 source configs/config
-set +e
 source bin/usage.sh
 
 role_name="$FUNCTION_NAME"Role


### PR DESCRIPTION
The previous solution used set to turn on and off erroring when encountering an error. This was not explicit and hard to read.